### PR TITLE
Auto assign chapter grouping to chapter non-container files

### DIFF
--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/usecases/ParseFileName.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/usecases/ParseFileName.kt
@@ -1,10 +1,11 @@
 package org.bibletranslationtools.maui.common.usecases
 
-import io.reactivex.Single
 import org.bibletranslationtools.maui.common.data.FileData
 import org.bibletranslationtools.maui.common.data.Grouping
 import org.bibletranslationtools.maui.common.data.MediaQuality
 import org.bibletranslationtools.maui.common.data.ResourceType
+import org.bibletranslationtools.maui.common.extensions.ContainerExtensions
+import org.bibletranslationtools.maui.common.extensions.MediaExtensions
 import java.io.File
 import java.util.regex.Matcher
 import java.util.regex.Pattern
@@ -111,7 +112,9 @@ class ParseFileName(private val file: File) {
                 _matcher.group(GROUPS.GROUPING.value) != null ->
                     Grouping.of(_matcher.group(GROUPS.GROUPING.value))
                 _matcher.group(GROUPS.LAST_VERSE.value) != null ->
-                    Grouping.of("chunk")
+                    Grouping.CHUNK
+                isChapterNonContainer(_matcher) ->
+                    Grouping.CHAPTER
                 else -> null
             }
         }
@@ -124,5 +127,12 @@ class ParseFileName(private val file: File) {
                 MediaQuality.of(it)
             }
         }
+    }
+
+    private fun isChapterNonContainer(matcher: Matcher): Boolean {
+        val mediaExtension = MediaExtensions.of(file.extension).norm
+        return matcher.group(GROUPS.CHAPTER.value).isNullOrBlank().not()
+                && matcher.group(GROUPS.FIRST_VERSE.value).isNullOrBlank()
+                && ContainerExtensions.isSupported(mediaExtension).not()
     }
 }

--- a/common/src/test/kotlin/org/bibletranslationtools/maui/common/usecases/MakePathTest.kt
+++ b/common/src/test/kotlin/org/bibletranslationtools/maui/common/usecases/MakePathTest.kt
@@ -131,6 +131,27 @@ class MakePathTest {
     }
 
     @Test
+    fun testNormalizeFilename() {
+        val expected = "en/ulb/gen/1/CONTENTS/mp3/hi/chapter/en_ulb_gen_c1.mp3"
+        val fileData = FileData(
+            File("test.mp3"),
+            "en",
+            ResourceType.ULB,
+            "gen",
+            1,
+            null,
+            MediaQuality.HI,
+            Grouping.CHAPTER
+        )
+
+        val result = MakePath(fileData).build().test()
+
+        result.assertComplete()
+        result.assertNoErrors()
+        result.assertValue(expected)
+    }
+
+    @Test
     fun testNonContainerWithMediaExtensionThrowsException() {
         val fileData = FileData(
             File("en_ulb_gen.mp3"),

--- a/jvm/build.gradle
+++ b/jvm/build.gradle
@@ -12,7 +12,7 @@ javafx {
     modules = ['javafx.controls', 'javafx.fxml']
 }
 
-version = 1.0
+version = 1.1
 
 repositories {
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }


### PR DESCRIPTION
Automatically set chapter grouping for chapter non-container files. File should have chapter number, shouldn't have verse numbers, should not be a container type (ex. TR)


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/maui/48)
<!-- Reviewable:end -->
