### PR TITLE
Update Otter Audio

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ buildscript {
 
 plugins {
     id 'nebula.lint' version "$nebulaLintPluginVer"
-    id 'com.gradle.build-scan' version "$buildscanPluginVer"
     id 'io.gitlab.arturbosch.detekt' version "$detektPluginVer"
 }
 
@@ -26,11 +25,6 @@ apply plugin: 'io.gitlab.arturbosch.detekt'
 
 repositories {
     mavenCentral()
-}
-
-buildScan {
-    termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-    termsOfServiceAgree = 'yes'
 }
 
 detekt {
@@ -59,6 +53,7 @@ subprojects {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlinVer"
+        implementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVer"
     }
 
     group 'org.bibletranslationtools'
@@ -66,12 +61,12 @@ subprojects {
 
     compileKotlin {
         kotlinOptions.jvmTarget = "11"
-        kotlinOptions.allWarningsAsErrors = true
+        kotlinOptions.allWarningsAsErrors = false
     }
 
     compileTestKotlin {
         kotlinOptions.jvmTarget = "11"
-        kotlinOptions.allWarningsAsErrors = true
+        kotlinOptions.allWarningsAsErrors = false
     }
 
     gradleLint.rules = ['deprecated-dependency-configuration']

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/audio/BttrMetadata.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/audio/BttrMetadata.kt
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAlias
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.databind.annotation.JsonSerialize
-import org.wycliffeassociates.otter.common.audio.wav.WavCue
+import org.wycliffeassociates.otter.common.audio.AudioCue
 
 data class BttrMetadata(
     var anthology: String = "",
@@ -21,5 +21,5 @@ data class BttrMetadata(
     var contributor: String = "",
     @JsonDeserialize(using = MarkerListDeserializer::class)
     @JsonSerialize(using = MarkerListSerializer::class)
-    var markers: MutableList<WavCue> = mutableListOf()
+    var markers: MutableList<AudioCue> = mutableListOf()
 )

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/audio/MarkerListJacksonUtils.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/audio/MarkerListJacksonUtils.kt
@@ -3,23 +3,23 @@ package org.bibletranslationtools.maui.common.audio
 import com.fasterxml.jackson.core.JsonGenerator
 import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.*
-import org.wycliffeassociates.otter.common.audio.wav.WavCue
+import org.wycliffeassociates.otter.common.audio.AudioCue
 import java.lang.IllegalArgumentException
 import java.text.ParseException
 
-class MarkerListDeserializer : JsonDeserializer<List<WavCue>>() {
-    override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): List<WavCue> {
+class MarkerListDeserializer : JsonDeserializer<List<AudioCue>>() {
+    override fun deserialize(p: JsonParser?, ctxt: DeserializationContext?): List<AudioCue> {
         val node = p?.codec?.readTree<JsonNode>(p) ?: throw ParseException("Unable to parse json", 0)
-        val cuePoints = mutableListOf<WavCue>()
+        val cuePoints = mutableListOf<AudioCue>()
         for (key in node.fieldNames()) {
-            cuePoints.add(WavCue(node.get(key).asInt(), key))
+            cuePoints.add(AudioCue(node.get(key).asInt(), key))
         }
         return cuePoints
     }
 }
 
-class MarkerListSerializer : JsonSerializer<List<WavCue>>() {
-    override fun serialize(value: List<WavCue>?, gen: JsonGenerator?, serializers: SerializerProvider?) {
+class MarkerListSerializer : JsonSerializer<List<AudioCue>>() {
+    override fun serialize(value: List<AudioCue>?, gen: JsonGenerator?, serializers: SerializerProvider?) {
         if (value == null) throw IllegalArgumentException("Input cannot be null")
         gen?.writeStartObject()
         for (cue in value) {

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/data/Grouping.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/data/Grouping.kt
@@ -11,7 +11,7 @@ enum class Grouping(val grouping: String) {
     companion object {
         fun of(grouping: String) =
             values().singleOrNull {
-                it.name == grouping.toUpperCase() || it.grouping == grouping
+                it.name == grouping.uppercase() || it.grouping == grouping
             } ?: throw IllegalArgumentException("Grouping $grouping is not supported")
     }
 

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/data/MediaExtension.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/data/MediaExtension.kt
@@ -8,7 +8,7 @@ enum class MediaExtension(vararg val ext: String) {
     companion object {
         fun of(ext: String) =
             values().singleOrNull {
-                it.name == ext.toUpperCase() || it.ext.contains(ext)
+                it.name == ext.uppercase() || it.ext.contains(ext)
             } ?: throw IllegalArgumentException("Media extension $ext is not supported")
     }
 

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/data/MediaQuality.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/data/MediaQuality.kt
@@ -9,7 +9,7 @@ enum class MediaQuality(val quality: String) {
     companion object {
         fun of(quality: String) =
             values().singleOrNull {
-                it.name == quality.toUpperCase() || it.quality == quality
+                it.name == quality.uppercase() || it.quality == quality
             } ?: throw IllegalArgumentException("Quality $quality is not supported")
     }
 

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/data/ResourceType.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/data/ResourceType.kt
@@ -8,7 +8,7 @@ enum class ResourceType(val slug: String) {
     companion object {
         fun of(slug: String) =
             values().singleOrNull {
-                it.name == slug.toUpperCase() || it.slug == slug
+                it.name == slug.uppercase() || it.slug == slug
             } ?: throw IllegalArgumentException("Resource type $slug is not supported")
     }
 

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/extensions/CompressedExtensions.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/extensions/CompressedExtensions.kt
@@ -7,7 +7,7 @@ enum class CompressedExtensions(vararg val ext: String) {
     companion object: SupportedExtensions {
         override fun isSupported(ext: String) =
             values().any {
-                it.name == ext.toUpperCase() || it.ext.contains(ext)
+                it.name == ext.uppercase() || it.ext.contains(ext)
             }
     }
 }

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/extensions/ContainerExtensions.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/extensions/ContainerExtensions.kt
@@ -6,7 +6,7 @@ enum class ContainerExtensions(val ext: String) {
     companion object: SupportedExtensions {
         override fun isSupported(ext: String) =
             values().any {
-                it.name == ext.toUpperCase() || it.ext == ext
+                it.name == ext.uppercase() || it.ext == ext
             }
     }
 }

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/extensions/MediaExtensions.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/extensions/MediaExtensions.kt
@@ -12,13 +12,13 @@ enum class MediaExtensions(vararg val ext: String) {
     companion object: SupportedExtensions {
         override fun isSupported(ext: String) =
             values().any {
-                it.name == ext.toUpperCase() || it.ext.contains(ext)
+                it.name == ext.uppercase() || it.ext.contains(ext)
             }
 
         @Throws(java.lang.IllegalArgumentException::class)
         fun of(ext: String) =
             values().singleOrNull {
-                it.name == ext.toUpperCase() || it.ext.contains(ext.toLowerCase())
+                it.name == ext.uppercase() || it.ext.contains(ext.lowercase())
             } ?: throw IllegalArgumentException("Media type $ext is not supported")
     }
 

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/usecases/MakePath.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/usecases/MakePath.kt
@@ -119,7 +119,7 @@ class MakePath(private val fileData: FileData) {
     private fun normalizeFileName(): String {
         val filename = if (hasVerse()) {
             val filenameWithoutExtension = fileData.file.nameWithoutExtension
-                .toLowerCase()
+                .lowercase()
 
             filenameWithoutExtension
         } else {

--- a/common/src/main/kotlin/org/bibletranslationtools/maui/common/usecases/ParseFileName.kt
+++ b/common/src/main/kotlin/org/bibletranslationtools/maui/common/usecases/ParseFileName.kt
@@ -78,7 +78,7 @@ class ParseFileName(private val file: File) {
 
     private fun findLanguage(): String? {
         return matcher?.let { _matcher ->
-            _matcher.group(GROUPS.LANGUAGE.value)?.toLowerCase()
+            _matcher.group(GROUPS.LANGUAGE.value)?.lowercase()
         }
     }
 
@@ -93,7 +93,7 @@ class ParseFileName(private val file: File) {
 
     private fun findBook(): String? {
         return matcher?.let { _matcher ->
-            _matcher.group(GROUPS.BOOK_SLUG.value)?.toLowerCase()
+            _matcher.group(GROUPS.BOOK_SLUG.value)?.lowercase()
         }
     }
 

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,13 +2,13 @@ ext {
     // Plugins
     javafxPluginVer = '0.0.8'
     nebulaLintPluginVer = '14.2.1'
-    buildscanPluginVer = '2.4.2'
+    buildscanPluginVer = '3.7.1'
     detektPluginVer = '1.10.0-RC1'
     ktlintPluginVer = '8.2.0'
     shadowPluginVer = '5.2.0'
 
     // Libraries
-    kotlinVer = '1.3.72'
+    kotlinVer = '1.5.10'
     javafxVer = '11'
     tornadofxVer = '2.0.0-SNAPSHOT'
     rxkotlinVer = '2.4.0'
@@ -23,7 +23,7 @@ ext {
     log4j2Ver = '2.12.1'
     ikonliVer = '11.3.4'
     aohVer = '1.3'
-    otterAudioVer = '0.0.3'
+    otterAudioVer = '0.3.2'
     tikaVer = '1.11'
     commonsnetVer = '3.7'
     launch4j = '2.4.6'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1-bin.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updating Otter Audio requires updating kotlin, which requires updating gradle, which breaks the build scan plugin. Some methods are deprecated (like createTempFile(), so warnings as errors are turned off. WavCue is replaced by AudioCue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bible-translation-tools/maui/52)
<!-- Reviewable:end -->
